### PR TITLE
Close the keyboard for the location search on mobile

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,9 +13,13 @@ const moduleExports = {
     ignoreBuildErrors: true,
   },
   compiler: {
-    removeConsole: {
-      exclude: ['error'],
-    },
+    ...(process.env.VERCEL_ENV === 'production'
+      ? {
+          removeConsole: {
+            exclude: ['error'],
+          },
+        }
+      : {}),
   },
   pageExtensions: ['page.tsx', 'page.ts'],
   async rewrites() {

--- a/src/components/LocationSearch/LocationSearch.tsx
+++ b/src/components/LocationSearch/LocationSearch.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useCombobox } from 'downshift';
 import { useTheme } from '@emotion/react';
@@ -24,6 +24,7 @@ const Input = styled.input(
 const LocationSearch = ({ onSelectedItemChange }) => {
   const [query, setQuery] = React.useState('');
   const theme = useTheme();
+  const inputRef = useRef(null);
 
   const { places, getPlaceLatLng } = useNominatimAutocomplete(query);
 
@@ -31,10 +32,10 @@ const LocationSearch = ({ onSelectedItemChange }) => {
     if (!selectedItem) {
       return;
     }
-
     const { lat, lng } = await getPlaceLatLng(selectedItem);
-
     onSelectedItemChange({ lat, lng });
+    // Remove focus from the input box, ensuring that the dropdown closes on mobile.
+    inputRef.current.blur();
   };
 
   const stateReducer = (
@@ -117,6 +118,7 @@ const LocationSearch = ({ onSelectedItemChange }) => {
           name="searchLocation"
           autoComplete="off"
           {...getInputProps({
+            ref: inputRef,
             onFocus: () => {
               if (isOpen) {
                 return;


### PR DESCRIPTION
## What does this change?

We had a user report that the keyboard on their mobile device wasn't closing after they finished searching for a location using the LocationSearch component.

This change ensures that we `blur` the search input when a search result is selected, causing the keyboard and menu to close - allowing users to immediately see the result of selecting the search result.

### Original feedback
> "When I search for toilets in a specific location, the keypad stays on the screen so I can't see the map, which makes this unusable."

### Misc.

* Enables console logs once again in development 