### PR TITLE
fix: crash accessing the api without a referer

### DIFF
--- a/src/pages/api/index.page.ts
+++ b/src/pages/api/index.page.ts
@@ -60,7 +60,7 @@ export const server = createServer({
   endpoint: '/api',
   schema: finalSchema,
   context: async ({ req, res }) => {
-    const revalidate = req.headers.referer.indexOf('message=') > -1;
+    const revalidate = req.headers.referer?.indexOf('message=') > -1;
     let user = null;
     try {
       // Support auth by header (legacy SPA and third-party apps)


### PR DESCRIPTION
Only browsers are likely to send a referer. This meant that all seemed well in GraphIQL and Apollo Explorer, but the api failed when handling queries conducted from elsewhere (e.g. curl)


