### PR TITLE
add a size limit to pagination

### DIFF
--- a/src/api/graphql/resolvers.ts
+++ b/src/api/graphql/resolvers.ts
@@ -41,6 +41,10 @@ const resolvers: Resolvers<Context> = {
         throw new Error('Invalid pagination params');
       }
 
+      if (pagination.limit > 100) {
+        throw new Error('Pagination size limit exceeded.');
+      }
+
       const noPaymentFilter =
         typeof filters.noPayment !== 'undefined'
           ? filters?.noPayment


### PR DESCRIPTION
## What does this change?

- Restricts the page size for our pagination api to 100 toilets per-page.
