### PR TITLE
Surface loo report information in Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "@hookform/error-message": "^2.0.1",
     "@monaco-editor/react": "^4.4.6",
     "@mui/base": "5.0.0-alpha.120",
+    "@mui/lab": "5.0.0-alpha.122",
+    "@mui/material": "^5.11.12",
     "@prisma/client": "^4.11.0",
     "@react-leaflet/core": "^2.1.0",
     "@sentry/nextjs": "^7.42.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,8 @@ specifiers:
   '@mapbox/geojson-rewind': ^0.5.2
   '@monaco-editor/react': ^4.4.6
   '@mui/base': 5.0.0-alpha.120
+  '@mui/lab': 5.0.0-alpha.122
+  '@mui/material': ^5.11.12
   '@next/bundle-analyzer': ^13.2.4
   '@prisma/client': ^4.11.0
   '@react-leaflet/core': ^2.1.0
@@ -152,6 +154,8 @@ dependencies:
   '@hookform/error-message': 2.0.1_fpf3xcttcup4i2fqpkvecidq4e
   '@monaco-editor/react': 4.4.6_waewrrayshn643ztij6zbniufy
   '@mui/base': 5.0.0-alpha.120_zula6vjvt3wdocc4mwcxqa6nzi
+  '@mui/lab': 5.0.0-alpha.122_buaezdclapb5fiedfif4i2kehi
+  '@mui/material': 5.11.12_xqeqsl5kvjjtyxwyi3jhw3yuli
   '@prisma/client': 4.11.0_prisma@4.11.0
   '@react-leaflet/core': 2.1.0_yydtlhsdonbqao6vgvkwhv2zki
   '@sentry/nextjs': 7.42.0_mvi2gotqcdgebuj3ci6acp6y7y
@@ -253,7 +257,7 @@ devDependencies:
   start-server-and-test: 2.0.0
   storybook: 6.5.16_a5ainwq6j6e77vl54wahuheooy
   storybook-addon-apollo-client: 4.0.13_gdcq4dv6opitr3wbfwyjmanyra
-  storybook-addon-next: 1.7.3_cm5kh46bxvr63m63cz5vrolki4
+  storybook-addon-next: 1.7.3_htisx7h3ntf6cluiasnmpgfgb4
   style-loader: 3.3.1_webpack@5.76.0
   supabase: 1.42.5
   topojson-server: 3.0.1
@@ -1898,7 +1902,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       '@types/react': 18.0.28
-      clsx: 1.1.0
+      clsx: 1.2.1
       focus-lock: 0.8.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -3447,6 +3451,30 @@ packages:
       glob-to-regexp: 0.3.0
     dev: true
 
+  /@mui/base/5.0.0-alpha.119_zula6vjvt3wdocc4mwcxqa6nzi:
+    resolution: {integrity: sha512-XA5zhlYfXi67u613eIF0xRmktkatx6ERy3h+PwrMN5IcWFbgiL1guz8VpdXON+GWb8+G7B8t5oqTFIaCqaSAeA==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@emotion/is-prop-valid': 1.2.0
+      '@mui/types': 7.2.3_@types+react@18.0.28
+      '@mui/utils': 5.11.12_react@18.2.0
+      '@popperjs/core': 2.11.6
+      '@types/react': 18.0.28
+      clsx: 1.2.1
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-is: 18.2.0
+    dev: false
+
   /@mui/base/5.0.0-alpha.120_zula6vjvt3wdocc4mwcxqa6nzi:
     resolution: {integrity: sha512-UoIXLjbl8ghK7OSD1dYzHIj79sx9v5S2J7vYeuhxUS0QR0FwGZ3WLHd31TQ2CT2faPX/AXsHQeFn93wKSnjPUQ==}
     engines: {node: '>=12.0.0'}
@@ -3469,6 +3497,149 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-is: 18.2.0
+    dev: false
+
+  /@mui/core-downloads-tracker/5.11.12:
+    resolution: {integrity: sha512-LHh8HZQ5nPVcW5QnyLwkAZ40txc/S2bzKMQ3bTO+5mjuwAJ2AzQrjZINLVy1geY7ei1pHXVqO1hcWHg/QdT44w==}
+    dev: false
+
+  /@mui/lab/5.0.0-alpha.122_buaezdclapb5fiedfif4i2kehi:
+    resolution: {integrity: sha512-rJyu9llUWAluUQgDEmN0WrpcFxeTdJgu+XYriJtp/MchdvKl/qVTlx+vhnIhqas2bySj5N1VQnkI6qOvfXiYvQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@mui/material': ^5.0.0
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@emotion/react': 11.10.6_pmekkgnqduwlme35zpnqhenc34
+      '@emotion/styled': 11.10.6_oouaibmszuch5k64ms7uxp2aia
+      '@mui/base': 5.0.0-alpha.120_zula6vjvt3wdocc4mwcxqa6nzi
+      '@mui/material': 5.11.12_xqeqsl5kvjjtyxwyi3jhw3yuli
+      '@mui/system': 5.11.12_d2lgyfpecxdc2bsiwyag5wf7ti
+      '@mui/types': 7.2.3_@types+react@18.0.28
+      '@mui/utils': 5.11.12_react@18.2.0
+      '@types/react': 18.0.28
+      clsx: 1.2.1
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-is: 18.2.0
+    dev: false
+
+  /@mui/material/5.11.12_xqeqsl5kvjjtyxwyi3jhw3yuli:
+    resolution: {integrity: sha512-M6BiIeJjySeEzWeiFJQ9pIjJy6mx5mHPWeMT99wjQdAmA2GxCQhE9A0fh6jQP4jMmYzxhOIhjsGcp0vSdpseXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@emotion/react': 11.10.6_pmekkgnqduwlme35zpnqhenc34
+      '@emotion/styled': 11.10.6_oouaibmszuch5k64ms7uxp2aia
+      '@mui/base': 5.0.0-alpha.119_zula6vjvt3wdocc4mwcxqa6nzi
+      '@mui/core-downloads-tracker': 5.11.12
+      '@mui/system': 5.11.12_d2lgyfpecxdc2bsiwyag5wf7ti
+      '@mui/types': 7.2.3_@types+react@18.0.28
+      '@mui/utils': 5.11.12_react@18.2.0
+      '@types/react': 18.0.28
+      '@types/react-transition-group': 4.4.5
+      clsx: 1.2.1
+      csstype: 3.1.1
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-is: 18.2.0
+      react-transition-group: 4.4.5_biqbaboplfbrettd7655fr4n2y
+    dev: false
+
+  /@mui/private-theming/5.11.12_pmekkgnqduwlme35zpnqhenc34:
+    resolution: {integrity: sha512-hnJ0svNI1TPeWZ18E6DvES8PB4NyMLwal6EyXf69rTrYqT6wZPLjB+HiCYfSOCqU/fwArhupSqIIkQpDs8CkAw==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@mui/utils': 5.11.12_react@18.2.0
+      '@types/react': 18.0.28
+      prop-types: 15.8.1
+      react: 18.2.0
+    dev: false
+
+  /@mui/styled-engine/5.11.11_xqp3pgpqjlfxxa3zxu4zoc4fba:
+    resolution: {integrity: sha512-wV0UgW4lN5FkDBXefN8eTYeuE9sjyQdg5h94vtwZCUamGQEzmCOtir4AakgmbWMy0x8OLjdEUESn9wnf5J9MOg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.4.1
+      '@emotion/styled': ^11.3.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@emotion/cache': 11.10.5
+      '@emotion/react': 11.10.6_pmekkgnqduwlme35zpnqhenc34
+      '@emotion/styled': 11.10.6_oouaibmszuch5k64ms7uxp2aia
+      csstype: 3.1.1
+      prop-types: 15.8.1
+      react: 18.2.0
+    dev: false
+
+  /@mui/system/5.11.12_d2lgyfpecxdc2bsiwyag5wf7ti:
+    resolution: {integrity: sha512-sYjsXkiwKpZDC3aS6O/6KTjji0jGINLQcrD5EJ5NTkIDiLf19I4HJhnufgKqlTWNfoDBlRohuTf3TzfM06c4ug==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@emotion/react': 11.10.6_pmekkgnqduwlme35zpnqhenc34
+      '@emotion/styled': 11.10.6_oouaibmszuch5k64ms7uxp2aia
+      '@mui/private-theming': 5.11.12_pmekkgnqduwlme35zpnqhenc34
+      '@mui/styled-engine': 5.11.11_xqp3pgpqjlfxxa3zxu4zoc4fba
+      '@mui/types': 7.2.3_@types+react@18.0.28
+      '@mui/utils': 5.11.12_react@18.2.0
+      '@types/react': 18.0.28
+      clsx: 1.2.1
+      csstype: 3.1.1
+      prop-types: 15.8.1
+      react: 18.2.0
     dev: false
 
   /@mui/types/7.2.3_@types+react@18.0.28:
@@ -6148,6 +6319,12 @@ packages:
       '@types/react': 18.0.28
     dev: false
 
+  /@types/react-transition-group/4.4.5:
+    resolution: {integrity: sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==}
+    dependencies:
+      '@types/react': 18.0.28
+    dev: false
+
   /@types/react/18.0.28:
     resolution: {integrity: sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==}
     dependencies:
@@ -6963,8 +7140,10 @@ packages:
       ajv: 6.12.6
     dev: true
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.12.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -8609,7 +8788,6 @@ packages:
   /clsx/1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
     engines: {node: '>=6'}
-    dev: false
 
   /cmd-shim/6.0.1:
     resolution: {integrity: sha512-S9iI9y0nKR4hwEQsVWpyxld/6kRfGepGfzff83FcaiEBpmvlbA2nnGe7Cylgrx2f/p1P5S5wpRm9oL8z1PbS3Q==}
@@ -9570,6 +9748,13 @@ packages:
       utila: 0.4.0
     dev: true
 
+  /dom-helpers/5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+    dependencies:
+      '@babel/runtime': 7.21.0
+      csstype: 3.1.1
+    dev: false
+
   /dom-serializer/1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
     dependencies:
@@ -9965,7 +10150,7 @@ packages:
       eslint: 8.35.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.3_yckic57kx266ph64dhq6ozvb54
-      eslint-plugin-import: 2.27.5_yiggpkcwtyhpwcphetqfqiayhm
+      eslint-plugin-import: 2.27.5_uyiasnnzcqrxqkfvjklwnmwcha
       eslint-plugin-jsx-a11y: 6.7.1_eslint@8.35.0
       eslint-plugin-react: 7.32.2_eslint@8.35.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.35.0
@@ -9995,7 +10180,7 @@ packages:
       debug: 4.3.4
       enhanced-resolve: 5.12.0
       eslint: 8.35.0
-      eslint-plugin-import: 2.27.5_yiggpkcwtyhpwcphetqfqiayhm
+      eslint-plugin-import: 2.27.5_uyiasnnzcqrxqkfvjklwnmwcha
       get-tsconfig: 4.4.0
       globby: 13.1.3
       is-core-module: 2.11.0
@@ -10005,7 +10190,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.4_4ew7aeh2ovxxbkkqgt5g5mz23a:
+  /eslint-module-utils/2.7.4_spn4godk7g7ml4zhqabnc6rdgi:
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -10030,7 +10215,6 @@ packages:
       debug: 3.2.7
       eslint: 8.35.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.3_yckic57kx266ph64dhq6ozvb54
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10057,7 +10241,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import/2.27.5_yiggpkcwtyhpwcphetqfqiayhm:
+  /eslint-plugin-import/2.27.5_uyiasnnzcqrxqkfvjklwnmwcha:
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -10075,7 +10259,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.35.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4_4ew7aeh2ovxxbkkqgt5g5mz23a
+      eslint-module-utils: 2.7.4_spn4godk7g7ml4zhqabnc6rdgi
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3
@@ -16265,6 +16449,20 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /react-transition-group/4.4.5_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+    dependencies:
+      '@babel/runtime': 7.21.0
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
   /react/18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
@@ -16934,7 +17132,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.12.0
       ajv-keywords: 5.1.0_ajv@8.12.0
     dev: true
 
@@ -17487,10 +17685,11 @@ packages:
       - react-dom
     dev: true
 
-  /storybook-addon-next/1.7.3_cm5kh46bxvr63m63cz5vrolki4:
+  /storybook-addon-next/1.7.3_htisx7h3ntf6cluiasnmpgfgb4:
     resolution: {integrity: sha512-CgtcuOI/uf9djH14wvGgaldfOeSopcEF249DssSHnF1ikrkpstSCXqHPx6CDKm2LWVUsY10nWgxSFIaH6zg7Zg==}
     peerDependencies:
       '@storybook/addon-actions': ^6.0.0
+      '@storybook/addons': ^6.0.0
       next: ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0

--- a/src/@types/resolvers-types.ts
+++ b/src/@types/resolvers-types.ts
@@ -231,6 +231,7 @@ export type Report = {
   contributor: Scalars['String'];
   /** When the report was added to the system */
   createdAt: Scalars['DateTime'];
+  geohash?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   location?: Maybe<Point>;
   /** The Loo which uses the data submitted in this report */
@@ -537,6 +538,7 @@ export type ReportResolvers<ContextType = any, ParentType extends ResolversParen
   children?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   contributor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  geohash?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   location?: Resolver<Maybe<ResolversTypes['Point']>, ParentType, ContextType>;
   loo?: Resolver<Maybe<ResolversTypes['Loo']>, ParentType, ContextType>;

--- a/src/@types/resolvers-types.ts
+++ b/src/@types/resolvers-types.ts
@@ -233,6 +233,11 @@ export type Report = {
   createdAt: Scalars['DateTime'];
   geohash?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
+  /**
+   * We insert location updates separately using a DB trigger because Prisma doesn't support PostGIS yet.
+   * This field is used to indicate to the client that the system created the report so that it can be coalesced with the user's report.
+   */
+  isSystemReport?: Maybe<Scalars['Boolean']>;
   location?: Maybe<Point>;
   /** The Loo which uses the data submitted in this report */
   loo?: Maybe<Loo>;
@@ -540,6 +545,7 @@ export type ReportResolvers<ContextType = any, ParentType extends ResolversParen
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   geohash?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  isSystemReport?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   location?: Resolver<Maybe<ResolversTypes['Point']>, ParentType, ContextType>;
   loo?: Resolver<Maybe<ResolversTypes['Loo']>, ParentType, ContextType>;
   men?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;

--- a/src/api-client/operations/looReportFragment.graphql
+++ b/src/api-client/operations/looReportFragment.graphql
@@ -24,8 +24,10 @@ fragment LooReportFragment on Report {
   removalReason
   attended
   geohash
+  isSystemReport
+  contributor
+
   # loo
-  # contributor
   # area {
   #   name
   #   type

--- a/src/api-client/operations/looReportFragment.graphql
+++ b/src/api-client/operations/looReportFragment.graphql
@@ -1,0 +1,33 @@
+fragment LooReportFragment on Report {
+  id
+  createdAt
+  verifiedAt
+  active
+  location {
+    lat
+    lng
+  }
+  name
+  openingTimes
+  accessible
+  men
+  women
+  allGender
+  babyChange
+  children
+  urinalOnly
+  radar
+  automatic
+  noPayment
+  paymentDetails
+  notes
+  removalReason
+  attended
+  geohash
+  # loo
+  # contributor
+  # area {
+  #   name
+  #   type
+  # }
+}

--- a/src/api-client/operations/looReportHistory.graphql
+++ b/src/api-client/operations/looReportHistory.graphql
@@ -1,0 +1,7 @@
+#import "./looReportFragment.graphql"
+
+query looReportHistory($id: ID!) {
+  reportsForLoo(id: $id) {
+    ...LooReportFragment
+  }
+}

--- a/src/api/graphql/resolvers.ts
+++ b/src/api/graphql/resolvers.ts
@@ -216,10 +216,14 @@ const resolvers: Resolvers<Context> = {
         },
         select: {
           record: true,
+          id: true,
         },
       });
 
-      const postgresAuditRecordToGraphQLReport = (diff: toilets): Report => {
+      const postgresAuditRecordToGraphQLReport = (
+        reportId: bigint,
+        diff: toilets
+      ): Report => {
         const contributor = diff.contributors.pop();
         // TODO: This return is incomplete, we need to support loo, area and contributors (when authenticated only.)
         return {
@@ -243,7 +247,7 @@ const resolvers: Resolvers<Context> = {
           notes: diff.notes,
           automatic: diff.automatic,
           contributor: contributor,
-          id: diff.id,
+          id: reportId.toString(),
           isSystemReport: contributor.endsWith('-location'),
           location: diff.location?.coordinates
             ? {
@@ -256,7 +260,7 @@ const resolvers: Resolvers<Context> = {
 
       const filtered = auditRecords.map((v) =>
         // TODO: use zod to validate the shape of the record.
-        postgresAuditRecordToGraphQLReport(v.record)
+        postgresAuditRecordToGraphQLReport(v.id, v.record)
       );
 
       // Order by report creation time.

--- a/src/api/graphql/resolvers.ts
+++ b/src/api/graphql/resolvers.ts
@@ -263,13 +263,6 @@ const resolvers: Resolvers<Context> = {
         postgresAuditRecordToGraphQLReport(v.id, v.record)
       );
 
-      // Order by report creation time.
-      // filtered.sort((b, a) => {
-      //   return (
-      //     new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-      //   );
-      // });
-
       return filtered;
     },
   },

--- a/src/api/graphql/resolvers.ts
+++ b/src/api/graphql/resolvers.ts
@@ -263,6 +263,25 @@ const resolvers: Resolvers<Context> = {
         postgresAuditRecordToGraphQLReport(v.id, v.record)
       );
 
+      // Order by report creation time.
+      // We make sure that user reports sit before system reports as they are made at the same time.
+      filtered.sort((b, a) => {
+        const aTime = new Date(a.createdAt).getTime();
+        const bTime = new Date(b.createdAt).getTime();
+
+        if (aTime === bTime) {
+          if (a.isSystemReport) {
+            return -1;
+          }
+          if (b.isSystemReport) {
+            return 1;
+          }
+          return 0;
+        }
+
+        return bTime - aTime;
+      });
+
       return filtered;
     },
   },

--- a/src/api/graphql/resolvers.ts
+++ b/src/api/graphql/resolvers.ts
@@ -247,7 +247,8 @@ const resolvers: Resolvers<Context> = {
           notes: diff.notes,
           automatic: diff.automatic,
           geohash: diff.geohash,
-          contributor: contributor,
+          // TODO: We don't want to return contributor info until we can redact it for non-authenticated users.
+          contributor: 'Anonymous',
           id: reportId.toString(),
           isSystemReport: contributor.endsWith('-location'),
           location: diff.location?.coordinates

--- a/src/api/graphql/resolvers.ts
+++ b/src/api/graphql/resolvers.ts
@@ -220,6 +220,7 @@ const resolvers: Resolvers<Context> = {
       });
 
       const postgresAuditRecordToGraphQLReport = (diff: toilets): Report => {
+        const contributor = diff.contributors.pop();
         // TODO: This return is incomplete, we need to support loo, area and contributors (when authenticated only.)
         return {
           createdAt: diff.updated_at,
@@ -241,8 +242,9 @@ const resolvers: Resolvers<Context> = {
           attended: diff.attended,
           notes: diff.notes,
           automatic: diff.automatic,
-          contributor: 'Anonymous',
+          contributor: contributor,
           id: diff.id,
+          isSystemReport: contributor.endsWith('-location'),
           location: diff.location?.coordinates
             ? {
                 lat: diff.location?.coordinates[1],
@@ -258,11 +260,11 @@ const resolvers: Resolvers<Context> = {
       );
 
       // Order by report creation time.
-      filtered.sort((b, a) => {
-        return (
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-        );
-      });
+      // filtered.sort((b, a) => {
+      //   return (
+      //     new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      //   );
+      // });
 
       return filtered;
     },

--- a/src/api/graphql/resolvers.ts
+++ b/src/api/graphql/resolvers.ts
@@ -246,6 +246,7 @@ const resolvers: Resolvers<Context> = {
           attended: diff.attended,
           notes: diff.notes,
           automatic: diff.automatic,
+          geohash: diff.geohash,
           contributor: contributor,
           id: reportId.toString(),
           isSystemReport: contributor.endsWith('-location'),

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -97,6 +97,7 @@ type Report {
   attended: Boolean
   automatic: Boolean
   noPayment: Boolean
+  geohash: String
   paymentDetails: String
   notes: String
   removalReason: String

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -77,6 +77,11 @@ type Report {
   createdAt: DateTime!
   verifiedAt: DateTime
   """
+  We insert location updates separately using a DB trigger because Prisma doesn't support PostGIS yet.
+  This field is used to indicate to the client that the system created the report so that it can be coalesced with the user's report.
+  """
+  isSystemReport: Boolean
+  """
   A link to the previous report in the chain
   This is nullable since this might be the first report about a particular toilet
   """

--- a/src/components/ToiletDetailsPanel.tsx
+++ b/src/components/ToiletDetailsPanel.tsx
@@ -6,20 +6,10 @@ import {
   faDirections,
   faList,
   faTimes,
-  faCheck,
-  faPoundSign,
-  faBaby,
-  faToilet,
-  faMale,
-  faFemale,
-  faChild,
-  faKey,
-  faCog,
-  faQuestion,
   faChevronDown,
   faSpinner,
 } from '@fortawesome/free-solid-svg-icons';
-import { faAccessibleIcon } from '@fortawesome/free-brands-svg-icons';
+
 import lightFormat from 'date-fns/lightFormat';
 import getISODay from 'date-fns/getISODay';
 import parseISO from 'date-fns/parseISO';
@@ -42,6 +32,7 @@ import { useRouter } from 'next/router';
 import { useSubmitVerificationReportMutationMutation } from '../api-client/graphql';
 import { usePlausible } from 'next-plausible';
 import Badge from '../design-system/components/Badge';
+import { getFeatures } from '../lib/features';
 
 const Grid = styled(Box)`
   display: flex;
@@ -214,83 +205,6 @@ const ToiletDetailsPanel: React.FC<ToiletDetailsPanelProps> = ({
     </Link>
   );
 
-  const getFeatureValueIcon = (value) => {
-    if (value === null) {
-      return (
-        <Box title="Unknown">
-          <Icon icon={faQuestion} color="tertiary" aria-label="Unknown" />
-        </Box>
-      );
-    }
-
-    return value ? (
-      <Box title="Available">
-        <Icon icon={faCheck} aria-label="Available" />
-      </Box>
-    ) : (
-      <Box title="Unavailable">
-        <Icon icon={faTimes} color="tertiary" aria-label="Unavailable" />
-      </Box>
-    );
-  };
-
-  const features = [
-    {
-      icon: <Icon icon={faFemale} />,
-      label: 'Women',
-      valueIcon: getFeatureValueIcon(data.women),
-    },
-    {
-      icon: <Icon icon={faMale} />,
-      label: 'Men',
-      valueIcon: getFeatureValueIcon(data.men),
-    },
-    {
-      icon: <Icon icon={faAccessibleIcon} />,
-      label: 'Accessible',
-      valueIcon: getFeatureValueIcon(data.accessible),
-    },
-    ...(data.accessible
-      ? [
-          {
-            icon: <Icon icon={faKey} />,
-            label: 'RADAR Key',
-            valueIcon: getFeatureValueIcon(data.radar),
-          },
-        ]
-      : []),
-    {
-      icon: <Icon icon={faToilet} />,
-      label: 'Gender Neutral',
-      valueIcon: getFeatureValueIcon(data.allGender),
-    },
-    {
-      icon: <Icon icon={faChild} />,
-      label: 'Children',
-      valueIcon: getFeatureValueIcon(data.children),
-    },
-    {
-      icon: <Icon icon={faBaby} />,
-      label: 'Baby Changing',
-      valueIcon: getFeatureValueIcon(data.babyChange),
-    },
-    {
-      icon: <Icon icon={faToilet} />,
-      label: 'Urinal Only',
-      valueIcon: getFeatureValueIcon(data.urinalOnly),
-    },
-    {
-      icon: <Icon icon={faCog} />,
-      label: 'Automatic',
-      valueIcon: getFeatureValueIcon(data.automatic),
-    },
-    {
-      icon: <Icon icon={faPoundSign} />,
-      label: 'Free',
-      valueIcon: getFeatureValueIcon(data.noPayment),
-    },
-  ];
-
   const openingTimes = data.openingTimes || WEEKDAYS.map(() => null);
 
   const todayWeekdayIndex = getISODay(new Date());
@@ -310,6 +224,8 @@ const ToiletDetailsPanel: React.FC<ToiletDetailsPanelProps> = ({
   }
 
   const plausible = usePlausible();
+
+  const features = useMemo(() => getFeatures(data), [data]);
 
   const lastVerifiedFragment = useMemo(
     () => (

--- a/src/components/ToiletDetailsPanel.tsx
+++ b/src/components/ToiletDetailsPanel.tsx
@@ -25,7 +25,7 @@ import Spacer from './Spacer';
 import Icon from './Icon';
 import { Media } from './Media';
 // Suppress Opening Hours Heading during COVID-19
-import { WEEKDAYS, isClosed } from '../lib/openingTimes';
+import { WEEKDAYS, getTimeRangeLabel } from '../lib/openingTimes';
 import { useMapState } from './MapState';
 import type L from 'leaflet';
 import { useRouter } from 'next/router';
@@ -45,22 +45,6 @@ const Grid = styled(Box)`
 const UnstyledList = styled.ul`
   list-style: none;
 `;
-
-function getTimeRangeLabel(range: unknown[]) {
-  if (isClosed(range)) {
-    return 'Closed';
-  }
-
-  if (range && range.length === 2) {
-    if (range[0] === range[1]) {
-      return '24 Hours';
-    }
-
-    return range.join(' - ');
-  }
-
-  return 'Unknown';
-}
 
 // Suppress Opening Hours heading during COVID-19
 // function getIsOpenLabel(openingTimes = [], dateTime = new Date()) {

--- a/src/lib/features.tsx
+++ b/src/lib/features.tsx
@@ -1,5 +1,6 @@
 import Box from '../components/Box';
 import Icon from '../components/Icon';
+import type { Loo } from '../api-client/graphql';
 
 import {
   faTimes,
@@ -16,7 +17,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { faAccessibleIcon } from '@fortawesome/free-brands-svg-icons';
 
-const getFeatureValueIcon = (value) => {
+export const getFeatureValueIcon = (value?: boolean) => {
   if (value === null) {
     return (
       <Box title="Unknown">
@@ -36,7 +37,7 @@ const getFeatureValueIcon = (value) => {
   );
 };
 
-export const getFeatures = (data) => [
+export const getFeatures = (data: Loo) => [
   {
     icon: <Icon icon={faFemale} />,
     label: 'Women',

--- a/src/lib/features.tsx
+++ b/src/lib/features.tsx
@@ -1,0 +1,94 @@
+import Box from '../components/Box';
+import Icon from '../components/Icon';
+
+import {
+  faTimes,
+  faCheck,
+  faPoundSign,
+  faBaby,
+  faToilet,
+  faMale,
+  faFemale,
+  faChild,
+  faKey,
+  faCog,
+  faQuestion,
+} from '@fortawesome/free-solid-svg-icons';
+import { faAccessibleIcon } from '@fortawesome/free-brands-svg-icons';
+
+const getFeatureValueIcon = (value) => {
+  if (value === null) {
+    return (
+      <Box title="Unknown">
+        <Icon icon={faQuestion} color="tertiary" aria-label="Unknown" />
+      </Box>
+    );
+  }
+
+  return value ? (
+    <Box title="Available">
+      <Icon icon={faCheck} aria-label="Available" />
+    </Box>
+  ) : (
+    <Box title="Unavailable">
+      <Icon icon={faTimes} color="tertiary" aria-label="Unavailable" />
+    </Box>
+  );
+};
+
+export const getFeatures = (data) => [
+  {
+    icon: <Icon icon={faFemale} />,
+    label: 'Women',
+    valueIcon: getFeatureValueIcon(data.women),
+  },
+  {
+    icon: <Icon icon={faMale} />,
+    label: 'Men',
+    valueIcon: getFeatureValueIcon(data.men),
+  },
+  {
+    icon: <Icon icon={faAccessibleIcon} />,
+    label: 'Accessible',
+    valueIcon: getFeatureValueIcon(data.accessible),
+  },
+  ...(data.accessible
+    ? [
+        {
+          icon: <Icon icon={faKey} />,
+          label: 'RADAR Key',
+          valueIcon: getFeatureValueIcon(data.radar),
+        },
+      ]
+    : []),
+  {
+    icon: <Icon icon={faToilet} />,
+    label: 'Gender Neutral',
+    valueIcon: getFeatureValueIcon(data.allGender),
+  },
+  {
+    icon: <Icon icon={faChild} />,
+    label: 'Children',
+    valueIcon: getFeatureValueIcon(data.children),
+  },
+  {
+    icon: <Icon icon={faBaby} />,
+    label: 'Baby Changing',
+    valueIcon: getFeatureValueIcon(data.babyChange),
+  },
+  {
+    icon: <Icon icon={faToilet} />,
+    label: 'Urinal Only',
+    valueIcon: getFeatureValueIcon(data.urinalOnly),
+  },
+  {
+    icon: <Icon icon={faCog} />,
+    label: 'Automatic',
+    valueIcon: getFeatureValueIcon(data.automatic),
+  },
+  {
+    icon: <Icon icon={faPoundSign} />,
+    label: 'Free',
+    valueIcon: getFeatureValueIcon(data.noPayment),
+  },
+];

--- a/src/lib/openingTimes.ts
+++ b/src/lib/openingTimes.ts
@@ -17,6 +17,22 @@ const WEEKDAYS = [
   'Sunday',
 ];
 
+export function getTimeRangeLabel(range: unknown[]) {
+  if (isClosed(range)) {
+    return 'Closed';
+  }
+
+  if (range && range.length === 2) {
+    if (range[0] === range[1]) {
+      return '24 Hours';
+    }
+
+    return range.join(' - ');
+  }
+
+  return 'Unknown';
+}
+
 function getDateFromTime(timeRangeString: string, weekdayToCheck: number) {
   const [hours, minutes] = timeRangeString.split(':');
 

--- a/src/pages/explorer/index.page.tsx
+++ b/src/pages/explorer/index.page.tsx
@@ -75,16 +75,16 @@ const Stats = ({ data: { statistics } }: { data: StatisticsQuery }) => {
         <table
           css={css`
             border-collapse: collapse;
+            width: 100%;
             td,
             th {
               padding: 0.5rem;
             }
             tr:nth-child(odd) td {
-              background-color: ${theme.colors.lightGrey};
+              background-color: ${theme.colors.white};
             }
             tr:nth-child(even) td {
-              background-color: ${theme.colors.primary};
-              color: white;
+              background-color: ${theme.colors.lightGrey};
             }
           `}
         >

--- a/src/pages/explorer/loos/[id]/index.page.tsx
+++ b/src/pages/explorer/loos/[id]/index.page.tsx
@@ -14,8 +14,9 @@ import { useRouter } from 'next/router';
 import Notification from '../../../../components/Notification';
 import NotFound from '../../../404.page';
 import { css } from '@emotion/react';
-import {
+import type {
   FindLooByIdQuery,
+  LooReportFragmentFragment,
   LooReportHistoryQuery,
 } from '../../../../api-client/graphql';
 import { ApolloError } from '@apollo/client';
@@ -82,7 +83,9 @@ const LooPage: CustomLooByIdComp = (props) => {
 
   // Find the diff between the current and previous report
   const reportHistory = props?.reportData?.reportsForLoo;
-  const [reportDiffHistory, setReportDiffHistory] = useState([]);
+  const [reportDiffHistory, setReportDiffHistory] = useState<
+    LooReportFragmentFragment[]
+  >([]);
 
   useEffect(() => {
     if (reportHistory) {
@@ -102,6 +105,7 @@ const LooPage: CustomLooByIdComp = (props) => {
               {
                 ...currentReport,
                 location: nextReport.location,
+                geohash: nextReport.geohash,
               },
             ];
           }
@@ -121,16 +125,6 @@ const LooPage: CustomLooByIdComp = (props) => {
         const prevReport = squashedSystemReports[i - 1];
         // Find out what's changed, only keep those items.
         for (const key in report) {
-          if (
-            key === 'id' ||
-            key === 'createdAt' ||
-            key === 'isSystemReport' ||
-            key === 'contributor' ||
-            key === '__typename'
-          ) {
-            continue;
-          }
-
           if (isEqual(report[key], prevReport[key])) {
             delete report[key];
           }
@@ -324,7 +318,11 @@ const LooPage: CustomLooByIdComp = (props) => {
                     <TimelineConnector />
                   </TimelineSeparator>
                   <TimelineContent>
-                    {JSON.stringify(report, null, 2)}
+                    <ul>
+                      {Object.entries(report).map(([k]) => (
+                        <li key={k}></li>
+                      ))}
+                    </ul>
                   </TimelineContent>
                 </TimelineItem>
               ))}

--- a/src/pages/explorer/loos/[id]/index.page.tsx
+++ b/src/pages/explorer/loos/[id]/index.page.tsx
@@ -40,6 +40,9 @@ import {
 } from '@mui/lab';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import isEqual from 'lodash/isEqual';
+import { WEEKDAYS, getTimeRangeLabel } from '../../../../lib/openingTimes';
+import { getISODay } from 'date-fns';
+import theme from '../../../../theme';
 
 type CustomLooByIdComp = React.FC<{
   looData?: FindLooByIdQuery;
@@ -319,9 +322,7 @@ const LooPage: CustomLooByIdComp = (props) => {
                   </TimelineSeparator>
                   <TimelineContent>
                     <ul>
-                      {Object.entries(report).map(([k]) => (
-                        <li key={k}></li>
-                      ))}
+                      <TimelineEntry key={report.id} report={report} />
                     </ul>
                   </TimelineContent>
                 </TimelineItem>
@@ -331,6 +332,84 @@ const LooPage: CustomLooByIdComp = (props) => {
         </Box>
       </Container>
     </Box>
+  );
+};
+
+const diffValueMapping = (key: string, value: unknown) => {
+  if (key === 'location') {
+    return (
+      <Box>
+        <p>
+          {value?.lat}, {value?.lng}
+        </p>
+      </Box>
+    );
+  }
+
+  if (key === 'openingTimes') {
+    const todayWeekdayIndex = getISODay(new Date());
+    return (
+      <ul>
+        {value?.map((timeRange: unknown[], i) => (
+          <Box
+            as="li"
+            display="flex"
+            justifyContent="space-between"
+            key={i}
+            padding={1}
+            bg={i === todayWeekdayIndex - 1 ? theme.colors.primary : 'white'}
+            color={i === todayWeekdayIndex - 1 ? 'white' : theme.colors.primary}
+            width={'15rem'}
+          >
+            <span>{WEEKDAYS[i]}</span>
+            <span>{getTimeRangeLabel(timeRange)}</span>
+          </Box>
+        ))}
+      </ul>
+    );
+  }
+
+  switch (key) {
+    default:
+      return <p>{JSON.stringify(value)}</p>;
+  }
+};
+
+const TimelineEntry = ({ report }: { report: LooReportFragmentFragment }) => {
+  return (
+    <table
+      css={css`
+        border-collapse: collapse;
+        width: 100%;
+        td,
+        th {
+          padding: 0.5rem;
+        }
+        tr:nth-child(odd) td {
+          background-color: ${theme.colors.white};
+        }
+        tr:nth-child(even) td {
+          background-color: ${theme.colors.lightGrey};
+        }
+      `}
+    >
+      <tbody>
+        <tr css={{ borderBottom: '1pt solid black' }}>
+          <th>
+            <Text fontWeight={'bold'}>Key</Text>
+          </th>
+          <th>
+            <Text fontWeight={'bold'}>Value</Text>
+          </th>
+        </tr>
+        {Object.entries(report).map(([key, value]) => (
+          <tr key={key + report.id} css={{ borderBottom: '1px solid black' }}>
+            <td>{key}</td>
+            <td>{diffValueMapping(key, value)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 };
 

--- a/src/pages/explorer/loos/[id]/index.page.tsx
+++ b/src/pages/explorer/loos/[id]/index.page.tsx
@@ -86,36 +86,21 @@ const LooPage: CustomLooByIdComp = (props) => {
 
   useEffect(() => {
     if (reportHistory) {
-      const coalescedReports = [];
-      let previousReport = {};
-      for (const reportIndex in reportHistory) {
-        const report = reportHistory[reportIndex];
-        const isSystemReport = report?.isSystemReport;
-        if (isSystemReport) {
-          coalescedReports.push({
-            ...previousReport,
-            ...report,
-          });
-        } else {
-          previousReport = report;
-        }
-      }
-
-      coalescedReports.sort((b, a) => {
+      const sortedReports = [...reportHistory].sort((b, a) => {
         return (
           new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
         );
       });
 
       // Merge each system report with the previous report
-      const diffHistory = coalescedReports.map((report, i) => {
+      const diffHistory = sortedReports.map((report, i) => {
         if (i === 0) {
           return report;
         }
-        const prevReport = coalescedReports[i - 1];
+        const prevReport = sortedReports[i - 1];
         // Find out what's changed, only keep those items.
         for (const key in report) {
-          if (key === 'id' || key === 'createdAt') {
+          if (key === 'id' || key === 'createdAt' || key === 'isSystemReport') {
             continue;
           }
 
@@ -125,7 +110,10 @@ const LooPage: CustomLooByIdComp = (props) => {
         }
         return report;
       });
-      setReportDiffHistory(diffHistory);
+
+      setReportDiffHistory(
+        diffHistory.filter((v) => v.isSystemReport === false)
+      );
     }
   }, [reportHistory]);
 
@@ -301,9 +289,8 @@ const LooPage: CustomLooByIdComp = (props) => {
               }}
             >
               {reportDiffHistory.map((report) => (
-                <TimelineItem
-                  key={report.id + report.createdAt + report.updatedAt}
-                >
+                // Only show non system location update reports for now.
+                <TimelineItem key={report.id}>
                   <TimelineOppositeContent>
                     {new Date(report.createdAt).toLocaleDateString()}
                   </TimelineOppositeContent>

--- a/src/pages/explorer/search.page.tsx
+++ b/src/pages/explorer/search.page.tsx
@@ -262,11 +262,10 @@ const UnstyledTable = () => {
             padding: 0.5rem;
           }
           tr:nth-child(odd) td {
-            background-color: ${theme.colors.lightGrey};
+            background-color: ${theme.colors.white};
           }
           tr:nth-child(even) td {
-            background-color: ${theme.colors.primary};
-            color: white;
+            background-color: ${theme.colors.lightGrey};
           }
         `}
       >


### PR DESCRIPTION
- Render toilet report history, allowing for users and @gailramster to see edit history properly on the website.
- Contributor names are redacted until we can check if users have the proper permissions to view them once again.
- User interface is quite minimal and has problems, it does the job - the purpose of this PR is mainly to bring the functionality back as it was missing in the initial Postgres migration
- Changes the sql seed so that system generated `*-location` contributors aren't included anymore, this is because when the db is seeded, only one audit record is made meaning that the two won't match up in the CODE environment. In PROD there is a 1-1 mapping between audit records and contributors listed

Report history is shown in a timeline format that looks like this:

<img width="462" alt="Screenshot 2023-03-21 at 16 01 36" src="https://user-images.githubusercontent.com/1771189/226667837-9d05e375-7552-41d5-89aa-9488e4596053.png">