### PR TITLE
Explorer | Fix diff logic, improve table spacing + consistency

### DIFF
--- a/src/api/graphql/resolvers.ts
+++ b/src/api/graphql/resolvers.ts
@@ -225,6 +225,7 @@ const resolvers: Resolvers<Context> = {
         diff: toilets
       ): Report => {
         const contributor = diff.contributors.pop();
+
         // TODO: This return is incomplete, we need to support loo, area and contributors (when authenticated only.)
         return {
           createdAt: diff.updated_at,

--- a/src/pages/explorer/loos/[id]/index.page.tsx
+++ b/src/pages/explorer/loos/[id]/index.page.tsx
@@ -345,9 +345,9 @@ const diffValueMapping = (key: string, value: unknown) => {
   if (key === 'location') {
     return (
       <Box>
-        <p>
+        <code>
           {value?.lat}, {value?.lng}
-        </p>
+        </code>
       </Box>
     );
   }
@@ -377,7 +377,7 @@ const diffValueMapping = (key: string, value: unknown) => {
 
   switch (key) {
     default:
-      return <p>{JSON.stringify(value)}</p>;
+      return <code>{JSON.stringify(value)}</code>;
   }
 };
 
@@ -412,7 +412,7 @@ const TimelineEntry = ({ report }: { report: LooReportFragmentFragment }) => {
           .filter(([key]) => key !== 'id' && key !== 'createdAt')
           .map(([key, value]) => (
             <tr key={key + report.id} css={{ borderBottom: '1px solid black' }}>
-              <td>{key}</td>
+              <td css={{ width: '10rem' }}>{key}</td>
               <td>{diffValueMapping(key, value)}</td>
             </tr>
           ))}


### PR DESCRIPTION
## What does this change?

- Previously, the report diffing logic was a bit off, not provding a true representation of what changed between reports. This amends that logic so that each timeline entry gives a realistic idea of what has changed, removing some noise.
- Fixes the table column alignment so it's less noisy and easier to read