### PR TITLE
fix: add/edit page min-zoom consistent with index page

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -68,7 +68,7 @@ const config = {
   initialZoom: 16,
   minZoom: 11,
   maxZoom: 18,
-  editMinZoom: 16,
+  editMinZoom: 5,
   fallbackLocation: {
     // Trafalgar Square. Because.
     lat: 51.507351,


### PR DESCRIPTION
## What does this change?

This should solve #1463 and is an adjustment to the editMinZoom in config.ts which makes the min zoom consistent across index and add/edit page.

## How was this tested?

Tested in local dev environment as change is minor.


## Accessibility

If applicable to your changes, have you:

- [ ] Tested with screen reader
- [ ] Checked to see if navigable by keyboard
- [ ] Ensured that the colour contrast is passing

## Documentation

If applicable to your changes, have you:

- [ ] Added/edited the appropriate documentation
- [ ] Added any component(s) to Storybook
