### PR TITLE
Nextjs 13 migration - Image and Link updates

### DIFF
--- a/src/components/EntryForm.tsx
+++ b/src/components/EntryForm.tsx
@@ -6,7 +6,7 @@ import {
   UseFormRegister,
   FieldValues,
 } from 'react-hook-form';
-import Image from 'next/legacy/image';
+import Image from 'next/image';
 import isFunction from 'lodash/isFunction';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 
 import Box from './Box';
 import Text from './Text';
-import Image from 'next/legacy/image';
+import Image from 'next/image';
 
 import poweredByVercel from '../../public/powered-by-vercel.svg';
 
@@ -42,23 +42,15 @@ const Footer = ({ children = null }) => {
           href={
             'https://vercel.com/?utm_source=public-convenience-ltd&utm_campaign=oss'
           }
-          passHref
-          legacyBehavior
+          target="_blank"
+          rel="noopener noreferrer"
         >
-          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-          <Box
-            as="a"
-            display={'flex'}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
             <Image
               width="130"
               src={poweredByVercel}
               alt="Powered by Vercel"
               unoptimized={!!process.env.STORYBOOK}
             />
-          </Box>
         </Link>
       </Box>
     </Box>

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Image from 'next/legacy/image';
+import Image from 'next/image';
 import Box from '../Box';
 import logo from '../../../public/logo.svg';
 
@@ -9,10 +9,14 @@ const Logo = React.forwardRef<HTMLDivElement>((props, ref) => (
     <Image
       src={logo}
       alt="The Great British Toilet Map"
-      layout="responsive"
       unoptimized={!!process.env.STORYBOOK}
       priority={true}
       {...props}
+      sizes="100vw"
+      style={{
+        width: "100%",
+        height: "auto"
+      }}
     />
   </Box>
 ));

--- a/src/components/ToiletDetailsPanel.tsx
+++ b/src/components/ToiletDetailsPanel.tsx
@@ -167,26 +167,21 @@ const ToiletDetailsPanel: React.FC<ToiletDetailsPanelProps> = ({
   );
 
   const getDirectionsFragment = (
-    <Link
-      passHref
+    <Button
+      variant="primary"
+      as={Link}
       href={`https://maps.apple.com/?dirflg=w&daddr=${[
         data.location.lat,
         data.location.lng,
       ]}`}
-      legacyBehavior
+      target="_blank"
+      rel="noopener noreferrer"
     >
-      <Button
-        variant="primary"
-        as="a"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <Box mr="2">
-          <Icon icon={faDirections} />
-        </Box>
-        Directions
-      </Button>
-    </Link>
+      <Box mr="2">
+        <Icon icon={faDirections} />
+      </Box>
+      Directions
+    </Button>
   );
 
   const openingTimes = data.openingTimes || WEEKDAYS.map(() => null);
@@ -241,14 +236,17 @@ const ToiletDetailsPanel: React.FC<ToiletDetailsPanelProps> = ({
           <Box display="flex" alignItems="center">
             No?
             <Spacer mr={2} />
-            <Link passHref href={editUrl} legacyBehavior>
-              <Button as="a" variant="secondary" data-testid="edit-button">
-                <Box mr={2}>
-                  <Icon icon={faEdit} />
-                </Box>
-                Edit
-              </Button>
-            </Link>
+            <Button
+              as={Link}
+              href={editUrl}
+              variant="secondary"
+              data-testid="edit-button"
+            >
+              <Box mr={2}>
+                <Icon icon={faEdit} />
+              </Box>
+              Edit
+            </Button>
           </Box>
         </Box>
         <Spacer mb={[0, 2]} />
@@ -256,7 +254,6 @@ const ToiletDetailsPanel: React.FC<ToiletDetailsPanelProps> = ({
         <Link
           href={`/explorer/loos/${data.id}`}
           prefetch={false}
-          legacyBehavior
         >
           {lightFormat(verifiedOrUpdatedDate, 'dd/MM/yyyy, hh:mm aa')}
         </Link>
@@ -442,10 +439,8 @@ const ToiletDetailsPanel: React.FC<ToiletDetailsPanelProps> = ({
               <Text fontSize={1} color="grey">
                 Hours may vary with national holidays or seasonal changes. If
                 you know these hours to be out of date please{' '}
-                <Link passHref href={editUrl} legacyBehavior>
-                  <Button as="a" variant="link" data-testid="edit-link">
+                <Link href={editUrl} data-testid="edit-link">
                     edit this toilet
-                  </Button>
                 </Link>
                 .
               </Text>

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,7 +68,7 @@ const config = {
   initialZoom: 16,
   minZoom: 11,
   maxZoom: 18,
-  editMinZoom: 16,
+  editMinZoom: 5,
   fallbackLocation: {
     // Trafalgar Square. Because.
     lat: 51.507351,

--- a/src/pages/500.page.tsx
+++ b/src/pages/500.page.tsx
@@ -27,7 +27,13 @@ const ThereWasAProblem = ({ children }) => (
           <p>
             Please try again later or, if the problem persists, please contact
             us at{' '}
-            <Button variant="link" as="a" href="mailto:gbtoiletmap@gmail.com">
+            <Button
+              variant="link"
+              as="a"
+              href="mailto:gbtoiletmap@gmail.com"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               gbtoiletmap@gmail.com
             </Button>
             .

--- a/src/pages/about.page.tsx
+++ b/src/pages/about.page.tsx
@@ -56,34 +56,28 @@ const AboutPage = () => {
           joint venture between researchers Dr Jo-Anne Bichard and Gail Ramster
           (who created the map at the RCA Helen Hamlyn Centre for Design) and
           software development company{' '}
-          <Link passHref href="https://www.neontribe.co.uk/" legacyBehavior>
-            <Button
-              variant="link"
-              as="a"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+          <Link
+            href="https://www.neontribe.co.uk/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
               Neontribe
-            </Button>
           </Link>{' '}
           (who designed and built it).
         </p>
         <p>
           The information comes from the public - anyone can go on the website
           and{' '}
-          <Link href="/" passHref legacyBehavior>
-            <Button variant="link">add, edit or remove toilets</Button>
+          <Link href="/">
+            add, edit or remove toilets
           </Link>
           . We also use open data and request information from councils,{' '}
-          <Link passHref href="https://www.openstreetmap.org/" legacyBehavior>
-            <Button
-              variant="link"
-              as="a"
-              target="_blank"
-              rel="noopener noreferrer"
+          <Link
+            href="https://www.openstreetmap.org/"
+            target="_blank"
+            rel="noopener noreferrer"
             >
               OpenStreetMap
-            </Button>
           </Link>
           , private companies and organisations.
         </p>
@@ -94,20 +88,15 @@ const AboutPage = () => {
           to download below.
         </p>
         <Spacer mb={2} />
-        <Link
-          passHref
+        <Button
+          variant="primary"
+          as={Link}
           href="Toilet.Map.Volunteer.Help.Guide.pdf"
-          legacyBehavior
+          target="_blank"
+          rel="noopener noreferrer"
         >
-          <Button
-            as="a"
-            variant="primary"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Download volunteer help guide
-          </Button>
-        </Link>
+          Download volunteer help guide
+        </Button>
         <Spacer mb={3} />
         <p>
           A handy printable checklist designed to make it easier for you to
@@ -115,16 +104,15 @@ const AboutPage = () => {
           also available for download.
         </p>
         <Spacer mb={2} />
-        <Link passHref href={'/GBPTM.Toilet.Checklist.pdf'} legacyBehavior>
-          <Button
-            as="a"
-            variant="primary"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Download toilet checklist
-          </Button>
-        </Link>
+        <Button
+          variant="primary"
+          as={Link}
+          href={'/GBPTM.Toilet.Checklist.pdf'}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Download toilet checklist
+        </Button>
         <SubHeading>Publicly Accessible Toilets</SubHeading>
         <p>
           The project aims to map all publicly-accessible toilets - that means
@@ -163,19 +151,16 @@ const AboutPage = () => {
         <p>
           If you have any problems updating the toilets, or wish to send us
           toilet details or comments, please contact{' '}
-          <Link passHref href="mailto:gbtoiletmap@gmail.com" legacyBehavior>
-            <Button variant="link" as="a">
+          <Link href="mailto:gbtoiletmap@gmail.com" target="_blank" rel="noopener noreferrer">
               gbtoiletmap@gmail.com
-            </Button>
           </Link>
           .
         </p>
         <SubHeading>The Explorer</SubHeading>
         <p>
-          <Link passHref href="/explorer" prefetch={false} legacyBehavior>
-            <Button variant="link" as="a">
+          <Link passHref href="/explorer" prefetch={false}>
               Visit the Explorer
-            </Button>
+
           </Link>
           &nbsp;to get an overview of the statistics and details related to the
           Toilet Map. These statistics are calculated on-demand, so will be up

--- a/src/pages/contact.page.tsx
+++ b/src/pages/contact.page.tsx
@@ -22,7 +22,13 @@ const ContactPage = () => {
         <p>
           If you have any problems updating the toilets, or wish to send us
           toilet details or comments, please contact{' '}
-          <Button variant="link" as="a" href="mailto:gbtoiletmap@gmail.com">
+          <Button
+            variant="link"
+            as="a"
+            href="mailto:gbtoiletmap@gmail.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             gbtoiletmap@gmail.com
           </Button>
           .

--- a/src/pages/login.page.tsx
+++ b/src/pages/login.page.tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 import styled from '@emotion/styled';
 import Container from '../components/Container';
 import Button from '../components/Button';
@@ -8,7 +9,6 @@ import Spacer from '../components/Spacer';
 import Box, { BoxProps } from '../components/Box';
 
 import config from '../config';
-import Link from 'next/link';
 
 const List = styled.ul`
   list-style: initial;
@@ -40,14 +40,13 @@ const LoginPage = () => {
           Up:
         </p>
         <Spacer mb={3} />
-        <Link
-          passHref
+        <Button
+          as={Link}
+          variant="primary"
           href={`/api/auth/login?returnTo=${router.asPath}`}
-          legacyBehavior>
-          <Button as={'a'} variant="primary">
-            Log In/Sign Up
-          </Button>
-        </Link>
+        >
+          Log In/Sign Up
+        </Button>
         <Spacer mb={4} />
         <Text fontSize={3} fontWeight="bold">
           <h2>Examples of Public toilets</h2>
@@ -91,7 +90,13 @@ const LoginPage = () => {
         <p>
           If you have any problems updating the toilets, or wish to send us
           toilet details or comments, please contact{' '}
-          <Button variant="link" as="a" href="mailto:gbtoiletmap@gmail.com">
+          <Button
+            variant="link"
+            as="a"
+            href="mailto:gbtoiletmap@gmail.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             gbtoiletmap@gmail.com
           </Button>
           .


### PR DESCRIPTION
## What does this change?
These changes mostly refer to the issue #1453 and there are three main refactors in this PR: 
- We are updating the Image component to use the next/image import and the non-legacy api, this deprecates the layout property and we need to apply the styles from this in either a style or as css. I ran the codemod on the migration guide which suggested the styles in Logo.tsx. 
- The second change is updating the Link behaviour so that we no longer are using legacyBehaviour.  We no longer need to use the passHref property or an `<a>` tag as a child. I've tried to keep the DOM structure as simple as possible, we can use the Button component to pass the Link which allows us to keep the styles of the button variants and ensuring we aren't including `<button>` tags inside of `<a>` tags.
- The third change is about consistency, and can be changed quickly if preferred, but I found that the email links did not have consistent behaviour so I've updated all email links to have the same behaviour

## How was this tested?
Local testing and checking in dev tools as I'm currently unable to run the Cypress e2e tests for any regressions but I've tried to ensure the same DOM structure and simplified where I can.

## Accessibility
Changes all resolve to valid <a> tags with no nested buttons inside.
If applicable to your changes, have you:

- [ ] Tested with screen reader
- [ ] Checked to see if navigable by keyboard
- [ ] Ensured that the colour contrast is passing

## Documentation

If applicable to your changes, have you:

- [ ] Added/edited the appropriate documentation
- [ ] Added any component(s) to Storybook
