### PR TITLE
style: remove max-width for buttons

### DIFF
--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -46,7 +46,7 @@ const Feedback = () => {
   };
 
   return (
-    <Stack spacing="1rem" padding="0.5rem">
+    <Stack spacing="1rem" padding="0.5rem" width="fit-content">
       {submitState === FeedbackState.SUCCESS && <Badge>Thank you!</Badge>}
 
       <Box

--- a/src/design-system/components/Button/Button.css
+++ b/src/design-system/components/Button/Button.css
@@ -5,7 +5,6 @@
   box-sizing: border-box;
   user-select: none;
   min-height: 34px;
-  max-width: 300px;
   border-radius: 17px;
   padding: 0 var(--space-s);
   border-style: solid;


### PR DESCRIPTION
If we want specific sizes for buttons we should add new variants. I think for now we shouldn't constrain the size of the buttons rather let them either fill the space given by the parent or be as large as they need to be as determined by their children.

## What does this change?

Removes the max-width for buttons

## How was this tested?

- Testing via Chromatic as this is only a visual change to the width of the button

## Accessibility

n/a

## Documentation

n/a
