### PR TITLE
Update to new Plausible proxy methods

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -59,5 +59,9 @@ const withNextAnalyser = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
 
+// https://plausible.io/docs/proxy/guides/nextjs
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { withPlausibleProxy } = require('next-plausible');
+
 // eslint-disable-next-line functional/immutable-data
-module.exports = withNextAnalyser(moduleExports);
+module.exports = withNextAnalyser(withPlausibleProxy()(moduleExports));

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -18,10 +18,7 @@ const Providers: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   }, [disableDynamicMediaQueries]);
 
   return (
-    <PlausibleProvider
-      domain="toiletmap.org.uk"
-      customDomain="https://stats.toiletmap.org.uk/"
-    >
+    <PlausibleProvider domain="toiletmap.org.uk">
       <MapStateProvider>
         {globalStyles}
         <ThemeProvider theme={theme}>


### PR DESCRIPTION
We use a same-domain proxy for our Plausible anlytics to reassure
privacy tools that we control our data carefully.

The support for doing this in Plausible changed from DNS level changes
to preferring local proxies. This is well-supported by next-plausible:
https://plausible.io/docs/proxy/guides/nextj


