### PR TITLE
Use a custom cluster marker style

### DIFF
--- a/src/components/LooMap/Markers.tsx
+++ b/src/components/LooMap/Markers.tsx
@@ -45,7 +45,7 @@ const Markers = () => {
       boundingBoxWest,
       boundingBoxNorth,
       boundingBoxEast,
-      geohashPrecision
+      geohashPrecision,
     );
   }, [
     boundingBoxEast,
@@ -131,7 +131,7 @@ const MarkerGroup: React.FC<{
           }),
           alt: 'Public Toilet',
           keyboard: false,
-        }
+        },
       )
         .on('click', () => {
           // Clear the current search upon navigation
@@ -151,20 +151,20 @@ const MarkerGroup: React.FC<{
       marker.getElement()?.setAttribute('aria-label', 'Public Toilet');
       return marker;
     },
-    [router, setMapState]
+    [router, setMapState],
   );
 
   const [appliedFilterTypes, setAppliedFilterTypes] = useState<
     Array<FILTER_TYPE>
   >(
     getAppliedFiltersAsFilterTypes(
-      config.filters.filter((filter) => filters?.[filter.id])
-    )
+      config.filters.filter((filter) => filters?.[filter.id]),
+    ),
   );
 
   useEffect(() => {
     const applied: Array<Filter> = config.filters.filter(
-      (filter) => filters?.[filter.id]
+      (filter) => filters?.[filter.id],
     );
     const appliedFilterTypes = getAppliedFiltersAsFilterTypes(applied);
     window.setTimeout(() => {
@@ -180,7 +180,7 @@ const MarkerGroup: React.FC<{
     const parsedAndFilteredMarkers = data?.loosByGeohash
       .map(parseCompressedLoo)
       .filter((compressedLoo) =>
-        filterCompressedLooByAppliedFilters(compressedLoo, appliedFilterTypes)
+        filterCompressedLooByAppliedFilters(compressedLoo, appliedFilterTypes),
       );
 
     return parsedAndFilteredMarkers
@@ -222,18 +222,9 @@ const MarkerGroup: React.FC<{
           .map((child) => child.getIcon().options?.toiletId)
           .join(',');
 
-        let c = ' marker-cluster-';
-        if (childCount < 10) {
-          c += 'small';
-        } else if (childCount < 100) {
-          c += 'medium';
-        } else {
-          c += 'large';
-        }
-
         return new L.DivIcon({
           html: `<div data-toilets=${containedIds}><span>${childCount}</span></div>`,
-          className: 'marker-cluster' + c,
+          className: 'marker-cluster',
           iconSize: new L.Point(40, 40),
         });
       },

--- a/src/design-system/components/stylesheet.css
+++ b/src/design-system/components/stylesheet.css
@@ -6,3 +6,16 @@
 @import 'src/design-system/components/Switch/Switch.css';
 @import 'src/design-system/components/TextArea/TextArea.css';
 @import 'src/design-system/components/Drawer/Drawer.css';
+
+/* Leaflet Marker Cluster custom styles */
+.leaflet-marker-icon.marker-cluster {
+    display: flex;
+    border: 0.25em solid #ED3D63;
+    background-color: white;
+    padding: 0.125em;
+    border-radius: 40px;
+}
+.leaflet-marker-icon.marker-cluster div {
+    margin: auto;
+    background-color: transparent;
+}


### PR DESCRIPTION
## What does this change?

| Before | After |
|--------|--------|
| <img width="1728" alt="before" src="https://github.com/public-convenience-ltd/toiletmap/assets/76776/48ef0aa8-cd3e-409c-acf9-4012a85825d8"> | <img width="1728" alt="after" src="https://github.com/public-convenience-ltd/toiletmap/assets/76776/e73585c6-1624-4799-bdb4-f4857a1aa306"> |

## How was this tested?

How have you tested your changes?

- Locally with `pnpm dev`

## Accessibility

If applicable to your changes, have you:

- [ ] Tested with screen reader
- [ ] Checked to see if navigable by keyboard
- [X] Ensured that the colour contrast is passing

## Documentation

If applicable to your changes, have you:

- [ ] Added/edited the appropriate documentation
- [ ] Added any component(s) to Storybook
