### PR TITLE
Set gh actions cypress action to v6 

### DIFF
--- a/.github/workflows/cypress-e2e-chrome.yml
+++ b/.github/workflows/cypress-e2e-chrome.yml
@@ -43,7 +43,7 @@ jobs:
           version: 1.27.7
       - run: SUPABASE_SCANNER_BUFFER_SIZE=5mb supabase start
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v6
         env:
           DATABASE_NAME: toiletmap
           VERCEL_URL: http://localhost:3000


### PR DESCRIPTION
## What does this change?

- We've been having persistent issues with our Cypress binary cache not being persisted properly across CI runs, hopefully this will resolve the issue after bumping the version of the Cypress gh action that we use to v6
- Maybe it won't, maybe it will : -)